### PR TITLE
Add ability to retrieve compressor from ZarrArray

### DIFF
--- a/src/main/java/com/bc/zarr/ZarrArray.java
+++ b/src/main/java/com/bc/zarr/ZarrArray.java
@@ -161,6 +161,10 @@ public class ZarrArray {
         return zarrArray;
     }
 
+    public Compressor getCompressor() {
+        return _compressor;
+    }
+
     public DataType getDataType() {
         return _dataType;
     }

--- a/src/test/java/com/bc/zarr/ZarrArrayDataReaderWriterTest_2D_writeAndReadData.java
+++ b/src/test/java/com/bc/zarr/ZarrArrayDataReaderWriterTest_2D_writeAndReadData.java
@@ -57,6 +57,22 @@ public class ZarrArrayDataReaderWriterTest_2D_writeAndReadData {
     }
 
     @Test
+    public void getCompressor() throws IOException {
+        final int[] shape = {1, 1};
+        final int[] chunkShape = {1, 1};
+        final DataType dataType = DataType.i1; // Byte
+        final Compressor compressor = CompressorFactory.nullCompressor;
+        final ArrayParams parameters = new ArrayParams()
+                .shape(shape).chunks(chunkShape)
+                .dataType(dataType)
+                .compressor(compressor);
+        final ZarrArray array = ZarrArray.create(
+                new ZarrPath(arrayName), store, parameters, null);
+        array.getCompressor();
+        assertEquals(compressor, array.getCompressor());
+    }
+
+    @Test
     public void writeAndRead_Byte_Full() throws IOException, InvalidRangeException {
         //preparation
         final int width = 7;


### PR DESCRIPTION
Particularly useful when performing downstream testing or interrogation of the configured compressor on a particular ZarrArray.