### PR TITLE
The BloscCompressor used InputStream.available() to determine if byte…

### DIFF
--- a/src/main/java/com/bc/zarr/CompressorFactory.java
+++ b/src/main/java/com/bc/zarr/CompressorFactory.java
@@ -207,6 +207,9 @@ public class CompressorFactory {
     }
 
     private static class BloscCompressor extends Compressor {
+
+        private static final int HEADER_SIZE = 16;
+
         private final int clevel;
         private final int blocksize;
         private final int shuffle;
@@ -312,10 +315,8 @@ public class CompressorFactory {
 
         @Override
         public void uncompress(InputStream is, OutputStream os) throws IOException {
-            while (is.available() >= 16) {
-                byte[] header = new byte[16];
-                is.read(header);
-
+            byte[] header = new byte[HEADER_SIZE];
+            while (is.read(header) == HEADER_SIZE) {
                 BufferSizes bs = cbufferSizes(ByteBuffer.wrap(header));
                 int chunkSize = (int) bs.getCbytes();
 

--- a/src/test/java/com/bc/zarr/CompressorTest.java
+++ b/src/test/java/com/bc/zarr/CompressorTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.*;
 
 import com.bc.zarr.chunk.ZarrInputStreamAdapter;
+import java.util.function.Function;
 import org.junit.*;
 
 import javax.imageio.stream.MemoryCacheImageInputStream;
@@ -162,6 +163,16 @@ public class CompressorTest {
             100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
             100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
             100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
             100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100
         };
         final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
@@ -172,16 +183,59 @@ public class CompressorTest {
         ByteArrayOutputStream os;
         InputStream is;
 
-        final byte[] intermediate = {2, 1, 33, 1, -36, 0, 0, 0, -36, 0, 0, 0, 73, 0, 0, 0, 20, 0, 0, 0, 49, 0, 0, 0, -5, 17, 0, 0, 0, 100, 0, 0, 0, 22, 0, 0, 0, 100, 0, 0, 0, 22, 0, 0, 0, 22, 0, 0, 0, 22, 0, 0, 0, 100, 0, 0, 0, 100, 32, 0, 0, 20, 0, 15, 44, 0, -111, 80, 22, 0, 0, 0, 100};
+        //write
+        os = new ByteArrayOutputStream();
+        compressor.compress(new ZarrInputStreamAdapter(iis), os);
+        final byte[] compressed = os.toByteArray();
+
+        //read
+        is = new MockAWSChecksumValidatingInputStream(new ByteArrayInputStream(compressed), len -> len > 16 ? 7 : len);
+        os = new ByteArrayOutputStream();
+        compressor.uncompress(is, os);
+        final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
+        final MemoryCacheImageInputStream resultIis = new MemoryCacheImageInputStream(bais);
+        resultIis.setByteOrder(byteOrder);
+        final int[] uncompressed = new int[input.length];
+        resultIis.readFully(uncompressed, 0, uncompressed.length);
+        assertThat(input, is(equalTo(uncompressed)));
+    }
+
+    @Test
+    public void read_BloscCompressor_ReducedBytesRead() throws IOException {
+        final Compressor compressor = CompressorFactory.create("blosc");
+        final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
+        final int[] input = {
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100
+        };
+        final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
+        iis.setByteOrder(byteOrder);
+        iis.writeInts(input, 0, input.length);
+        iis.seek(0);
+
+        ByteArrayOutputStream os;
+        InputStream is;
 
         //write
         os = new ByteArrayOutputStream();
         compressor.compress(new ZarrInputStreamAdapter(iis), os);
         final byte[] compressed = os.toByteArray();
-        assertThat(compressed, is(equalTo(intermediate)));
 
         //read
-        is = new MockAWSChecksumValidatingInputStream(new ByteArrayInputStream(compressed));
+        is = new MockAWSChecksumValidatingInputStream(new ByteArrayInputStream(compressed), len -> len > 1 ? len - 1 : len);
         os = new ByteArrayOutputStream();
         compressor.uncompress(is, os);
         final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
@@ -193,13 +247,17 @@ public class CompressorTest {
     }
 
     // Simulates a software.amazon.awssdk.services.s3.checksums.ChecksumValidatingInputStream which
-    // does not provide it's own implementation of available() and always returns 0
+    // does not provide it's own implementation of available() and always returns 0.
+    // Additionally, this class may return less bytes than requested from read(), this is allowed per
+    // the documentation
     private static class MockAWSChecksumValidatingInputStream extends InputStream {
 
         private final InputStream in;
+        private final Function<Integer, Integer> getBytesRead;
 
-        public MockAWSChecksumValidatingInputStream(InputStream in) {
+        public MockAWSChecksumValidatingInputStream(InputStream in, Function<Integer, Integer> getBytesRead) {
             this.in = in;
+            this.getBytesRead = getBytesRead;
         }
 
         @Override
@@ -207,9 +265,16 @@ public class CompressorTest {
             return in.read();
         }
 
+        /*
+         * From InputStream:
+         *
+         * Reads up to <code>len</code> bytes of data from the input stream into
+         * an array of bytes.  An attempt is made to read as many as
+         * <code>len</code> bytes, but a smaller number may be read.
+         */
         @Override
         public int read(byte[] buf, int off, int len) throws IOException {
-            return in.read(buf, off, len);
+            return in.read(buf, off, getBytesRead.apply(len));
         }
 
         @Override


### PR DESCRIPTION
The BloscCompressor used InputStream.available() to determine if bytes were available. InputStream.available() is not guaranteed to be accurate. Some implementations rely on the implementation provided by InputStream itself, which always returns 0. An EOFException was thrown in this case. One example of this is software.amazon.awssdk.services.s3.checksums.ChecksumValidatingInputStream.  The BlockCompressor was updated to just attempt to read from the stream and see if bytes were returned.