### PR TITLE
Array nesting: Add the ability to use N5-style nested layout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.bc.zarr</groupId>
     <artifactId>jzarr</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.2</version>
 
     <properties>
         <!-- needed in test scope to show examples -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.bc.zarr</groupId>
     <artifactId>jzarr</artifactId>
-    <version>0.3.2</version>
+    <version>0.3.99-SNAPSHOT</version>
 
     <properties>
         <!-- needed in test scope to show examples -->

--- a/src/main/java/com/bc/zarr/ArrayParams.java
+++ b/src/main/java/com/bc/zarr/ArrayParams.java
@@ -76,6 +76,18 @@ public class ArrayParams {
     private ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
     private Number fillValue = 0;
     private Compressor compressor = CompressorFactory.createDefaultCompressor();
+    private boolean nested = false;
+
+    /**
+     * Sets the optional {@code nested} flag. True signifies "nested" storage with chunks in a directory tree rather
+     * than all in the same directory. False significes a "flat" layout with all chunks in a single directory
+     * with the chunk index separated by a ".". Returns a reference to this builder so that the methods
+     * can be chained together.
+     */
+    public ArrayParams nested(boolean nested) {
+        this.nested = nested;
+        return this;
+    }
 
     /**
      * Sets the mandatory {@code shape} and returns a reference to this Builder so that the methods can be chained together.
@@ -212,7 +224,7 @@ public class ArrayParams {
             }
         }
 
-        return new Params(shape, chunks, dataType, byteOrder, fillValue, compressor);
+        return new Params(shape, chunks, dataType, byteOrder, fillValue, compressor, nested);
     }
 
     /**
@@ -225,14 +237,16 @@ public class ArrayParams {
         private final ByteOrder byteOrder;
         private final Number fillValue;
         private final Compressor compressor;
+        private final boolean nested;
 
-        private Params(int[] shape, int[] chunks, DataType dataType, ByteOrder byteOrder, Number fillValue, Compressor compressor) {
+        private Params(int[] shape, int[] chunks, DataType dataType, ByteOrder byteOrder, Number fillValue, Compressor compressor, boolean nested) {
             this.shape = shape;
             this.chunks = chunks;
             this.dataType = dataType;
             this.byteOrder = byteOrder;
             this.fillValue = fillValue;
             this.compressor = compressor;
+            this.nested = nested;
         }
 
         public int[] getShape() {
@@ -263,6 +277,8 @@ public class ArrayParams {
             return compressor;
         }
 
+        public boolean getNested() { return nested; };
+
         public ArrayParams toBuilder() {
             ArrayParams builder = new ArrayParams();
             builder.shape = getShape();
@@ -272,6 +288,7 @@ public class ArrayParams {
             builder.byteOrder = getByteOrder();
             builder.fillValue = getFillValue();
             builder.compressor = getCompressor();
+            builder.nested = getNested();
             return builder;
         }
     }

--- a/src/main/java/com/bc/zarr/ArrayParams.java
+++ b/src/main/java/com/bc/zarr/ArrayParams.java
@@ -76,7 +76,7 @@ public class ArrayParams {
     private ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
     private Number fillValue = 0;
     private Compressor compressor = CompressorFactory.createDefaultCompressor();
-    private boolean nested = false;
+    private Boolean nested = null;
 
     /**
      * Sets the optional {@code nested} flag. True signifies "nested" storage with chunks in a directory tree rather
@@ -84,7 +84,7 @@ public class ArrayParams {
      * with the chunk index separated by a ".". Returns a reference to this builder so that the methods
      * can be chained together.
      */
-    public ArrayParams nested(boolean nested) {
+    public ArrayParams nested(Boolean nested) {
         this.nested = nested;
         return this;
     }
@@ -237,9 +237,9 @@ public class ArrayParams {
         private final ByteOrder byteOrder;
         private final Number fillValue;
         private final Compressor compressor;
-        private final boolean nested;
+        private final Boolean nested;
 
-        private Params(int[] shape, int[] chunks, DataType dataType, ByteOrder byteOrder, Number fillValue, Compressor compressor, boolean nested) {
+        private Params(int[] shape, int[] chunks, DataType dataType, ByteOrder byteOrder, Number fillValue, Compressor compressor, Boolean nested) {
             this.shape = shape;
             this.chunks = chunks;
             this.dataType = dataType;
@@ -277,7 +277,7 @@ public class ArrayParams {
             return compressor;
         }
 
-        public boolean getNested() { return nested; };
+        public Boolean getNested() { return nested; };
 
         public ArrayParams toBuilder() {
             ArrayParams builder = new ArrayParams();

--- a/src/main/java/com/bc/zarr/ZarrArray.java
+++ b/src/main/java/com/bc/zarr/ZarrArray.java
@@ -46,6 +46,11 @@ import static com.bc.zarr.ZarrConstants.FILENAME_DOT_ZARRAY;
 
 public class ZarrArray {
 
+    private final static boolean DEFAULT_NESTED;
+    static {
+        DEFAULT_NESTED = Boolean.parseBoolean(System.getProperty("jzarr.nested", "false"));
+    }
+
     private final int[] _shape;
     private final int[] _chunks;
     private final ZarrPath relativePath;
@@ -77,7 +82,7 @@ public class ZarrArray {
     }
 
     private ZarrArray(ZarrPath relativePath, int[] shape, int[] chunkShape, DataType dataType, ByteOrder order, Number fillValue, Compressor compressor, Store store) {
-        this(relativePath, shape, chunkShape, dataType, order, fillValue, compressor, store, false);
+        this(relativePath, shape, chunkShape, dataType, order, fillValue, compressor, store, DEFAULT_NESTED);
     }
     public static ZarrArray open(String path) throws IOException {
         return open(Paths.get(path));
@@ -159,8 +164,10 @@ public class ZarrArray {
 
         if (nested == null) {
             // In this case, *no* chunk was found. Something is almost certainly wrong.
-            throw new IOException(String.format("Could find neither nested nor chunks (tried: %s)", attempts));
-
+            // However, not throwing an exception since there is a possibility that a client
+            // created an array but did not yet write data. An alternative would be to store
+            // the nested boolean with the .zarray metadata. (TODO incl. logging)
+            nested = DEFAULT_NESTED;
         }
         return new ZarrArray(relativePath, shape, chunks, dataType, byteOrder, fillValue, compressor, store, nested);
 

--- a/src/main/java/com/bc/zarr/ZarrUtils.java
+++ b/src/main/java/com/bc/zarr/ZarrUtils.java
@@ -98,11 +98,12 @@ public final class ZarrUtils {
         return chunkIndices;
     }
 
-    public static String createChunkFilename(int[] currentIdx) {
+    public static String createChunkFilename(int[] currentIdx, boolean nested) {
+        final char sep = nested ? '/' : '.';
         StringBuilder sb = new StringBuilder();
         for (int aCurrentIdx : currentIdx) {
             sb.append(aCurrentIdx);
-            sb.append(".");
+            sb.append(sep);
         }
         sb.setLength(sb.length() - 1);
         return sb.toString();

--- a/src/test/java/com/bc/zarr/ZarrUtilsTest.java
+++ b/src/test/java/com/bc/zarr/ZarrUtilsTest.java
@@ -152,7 +152,12 @@ public class ZarrUtilsTest {
 
     @Test
     public void computeChunkFilename() {
-        assertEquals("1.2.3.42", ZarrUtils.createChunkFilename(new int[]{1, 2, 3, 42}));
+        assertEquals("1.2.3.42", ZarrUtils.createChunkFilename(new int[]{1, 2, 3, 42}, false));
+    }
+
+    @Test
+    public void computeChunkFilename2() {
+        assertEquals("1/2/3/42", ZarrUtils.createChunkFilename(new int[]{1, 2, 3, 42}, true));
     }
 
     private String expectedJson(boolean nullCompressor) {


### PR DESCRIPTION
Having many millions of chunk files in a single directory causes
significant performance issues for filesystems. This PR introduces
a "nested" boolean to the ZarrArray class and related helpers in
order to choose between the separators "." and "/". The main
downside of nested storage is that one must search through the
chunk index names in order to determine whether or not an array
is nested.

### Discussion:

A few similar strategies exist in the zarr-python code base. [NestedStorage](https://github.com/zarr-developers/zarr-python/blob/master/zarr/storage.py#L1173) was the original attempt with the downside that it was not composable with other stores. A newer version, [FSStore](https://github.com/zarr-developers/zarr-python/blob/master/zarr/storage.py#L1000), allows passing a "key_separator". Here, I've chosen the boolean to reduce the burden on the caller. A type other than "boolean" ("ChunkNamer"?) might be preferred. Note also that no other implementation that I know of currently tries to detect "nested or not nested" as we're doing here. It may be overkill.