### PR TITLE
Introduced USE_BLOSC profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ target/
 /docs/examples/java/S3Array_nio_amazon.java
 /docs/examples/java/S3Array_nio_telecom_cloud.java
 /maven.properties
+/blosc.properties

--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 # JZarr
 
-A Java version of the API offered by the wonderful Python [zarr](https://zarr.readthedocs.io/) package.
+A Java version of the wonderful Python [zarr](https://zarr.readthedocs.io/) API.
 
-
-This API also uses blosc compression. To use this compression, a compiled c-blosc distributed library must be available on the operating system. 
+## Build Documentation
+This API is able to use blosc compression. To use this compression, a compiled c-blosc distributed library must be available on the operating system. 
 If such a library is not available ... The C sourcecode and instructions to build the library can be found at https://github.com/Blosc/c-blosc.
 If you want to use the JZarr API and the integrated blosc compression, you have to start the Java Virtual Machine with the following VM parameter:
 
     -Djna.library.path=<path which contains the compiled c-blosc library>
 
-## Documentation
-You can find detailed information at [JZarrs project documentation](https://jzarr.readthedocs.io) page.  
+In order to include the blosc library for testing during the build process you need to create a copy of the 
+`template.blosc.properties` file and rename the copy to `blosc.properties`. 
+Provide the path to the `bloscJnaLibraryPath` property as explained in the comments of within the file.
 
+## Library Documentation
+The latest detailed information can be found at [JZarrs project documentation](https://jzarr.readthedocs.io) page.  
 
-## Build Documentation
+## Generating the Documentation
 The projects documentation is automatically generated and provided using "Read the Docs".
-Some files, needed to build the "**read the docs**" documentation must be generated to be up to
-date and along with the code. Therefor a class has been implemented which searches for
-classes whose filename ends with "_rtd.java" and invokes whose **`main`** method.
-Rerun the class (**`ExecuteForReadTheDocs`**) to autogenerate these
-referenced files.
+Some files, needed to build the "**Read the Docs**" documentation must be generated to be up to
+date and along with the code. Therefore, a class has been implemented which searches for
+classes whose filename ends with "_rtd.java" and invokes there `main` method.
+Rerun the class (`ExecuteForReadTheDocs`) to autogenerate these
+referenced files. The `bloscJnaLibraryPath` is also necessary for generating the "Read the Docs" files.

--- a/docs/examples/java/ExecuteForReadTheDocs.java
+++ b/docs/examples/java/ExecuteForReadTheDocs.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 public class ExecuteForReadTheDocs {
     public static void main(String[] args) throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         final Properties properties = new Properties();
-        properties.load(Files.newBufferedReader(Paths.get("maven.properties")));
+        properties.load(Files.newBufferedReader(Paths.get("blosc.properties")));
         System.setProperty("jna.library.path", properties.getProperty("bloscJnaLibraryPath"));
 
         Path workingDir = Paths.get(".");

--- a/pom.xml
+++ b/pom.xml
@@ -140,24 +140,24 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
-                <executions>
-                    <execution>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>read-project-properties</goal>
-                        </goals>
-                        <configuration>
-                            <files>
-                                <file>${basedir}/maven.properties</file>
-                            </files>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+            <!--            <plugin>-->
+            <!--                <groupId>org.codehaus.mojo</groupId>-->
+            <!--                <artifactId>properties-maven-plugin</artifactId>-->
+            <!--                <version>1.0.0</version>-->
+            <!--                <executions>-->
+            <!--                    <execution>-->
+            <!--                        <phase>initialize</phase>-->
+            <!--                        <goals>-->
+            <!--                            <goal>read-project-properties</goal>-->
+            <!--                        </goals>-->
+            <!--                        <configuration>-->
+            <!--                            <files>-->
+            <!--                                <file>${basedir}/maven.properties</file>-->
+            <!--                            </files>-->
+            <!--                        </configuration>-->
+            <!--                    </execution>-->
+            <!--                </executions>-->
+            <!--            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -208,15 +208,53 @@
                     </excludes>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <configuration>
-                    <argLine>-Djna.library.path=${bloscJnaLibraryPath}</argLine>
-                </configuration>
-            </plugin>
+            <!--            <plugin>-->
+            <!--                <groupId>org.apache.maven.plugins</groupId>-->
+            <!--                <artifactId>maven-surefire-plugin</artifactId>-->
+            <!--                <version>3.0.0-M5</version>-->
+            <!--                <configuration>-->
+            <!--                    <argLine>-Djna.library.path=${bloscJnaLibraryPath}</argLine>-->
+            <!--                </configuration>-->
+            <!--            </plugin>-->
         </plugins>
+
     </build>
+    <profiles>
+        <profile>
+            <id>USE_BLOSC</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <version>1.0.0</version>
+                        <executions>
+                            <execution>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>read-project-properties</goal>
+                                </goals>
+                                <configuration>
+                                    <files>
+                                        <file>${basedir}/blosc.properties</file>
+                                    </files>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                        <configuration>
+                            <argLine>-Djna.library.path=${bloscJnaLibraryPath}</argLine>
+                            <systemPropertiesFile>${basedir}/blosc.properties</systemPropertiesFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/java/com/bc/zarr/storage/FileSystemStore.java
+++ b/src/main/java/com/bc/zarr/storage/FileSystemStore.java
@@ -38,6 +38,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -108,15 +109,16 @@ public class FileSystemStore implements Store {
 
     @Override
     public TreeSet<String> getArrayKeys() throws IOException {
-        return getKeysFor(ZarrConstants.FILENAME_DOT_ZARRAY);
+        return getKeysEndingWith(ZarrConstants.FILENAME_DOT_ZARRAY);
     }
 
     @Override
     public TreeSet<String> getGroupKeys() throws IOException {
-        return getKeysFor(ZarrConstants.FILENAME_DOT_ZGROUP);
+        return getKeysEndingWith(ZarrConstants.FILENAME_DOT_ZGROUP);
     }
 
-    private TreeSet<String> getKeysFor(String suffix) throws IOException {
+    @Override
+    public TreeSet<String> getKeysEndingWith(String suffix) throws IOException {
         return Files.walk(internalRoot)
                 .filter(path -> path.getFileName().toString().endsWith(suffix))
                 .map(path -> internalRoot.relativize(path.getParent()).toString())

--- a/src/main/java/com/bc/zarr/storage/InMemoryStore.java
+++ b/src/main/java/com/bc/zarr/storage/InMemoryStore.java
@@ -28,10 +28,7 @@ package com.bc.zarr.storage;
 
 import com.bc.zarr.ZarrConstants;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.*;
 
 public class InMemoryStore implements Store {
@@ -65,15 +62,16 @@ public class InMemoryStore implements Store {
 
     @Override
     public TreeSet<String> getArrayKeys() {
-        return getKeysFor(ZarrConstants.FILENAME_DOT_ZARRAY);
+        return getKeysEndingWith(ZarrConstants.FILENAME_DOT_ZARRAY);
     }
 
     @Override
     public TreeSet<String> getGroupKeys() {
-        return getKeysFor(ZarrConstants.FILENAME_DOT_ZGROUP);
+        return getKeysEndingWith(ZarrConstants.FILENAME_DOT_ZGROUP);
     }
 
-    private TreeSet<String> getKeysFor(String suffix) {
+    @Override
+    public TreeSet<String> getKeysEndingWith(String suffix) {
         final Set<String> keySet = map.keySet();
         final TreeSet<String> arrayKeys = new TreeSet<>();
         for (String key : keySet) {

--- a/src/main/java/com/bc/zarr/storage/Store.java
+++ b/src/main/java/com/bc/zarr/storage/Store.java
@@ -51,6 +51,8 @@ public interface Store extends Closeable {
 
     Set<String> getGroupKeys() throws IOException;
 
+    Set<String> getKeysEndingWith(String suffix) throws IOException;
+
     @Override
     default void close() throws IOException {
     }

--- a/src/main/java/com/bc/zarr/storage/ZipStore.java
+++ b/src/main/java/com/bc/zarr/storage/ZipStore.java
@@ -40,6 +40,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -108,15 +109,16 @@ public class ZipStore implements Store {
 
     @Override
     public TreeSet<String> getArrayKeys() throws IOException {
-        return getKeysFor(ZarrConstants.FILENAME_DOT_ZARRAY);
+        return getKeysEndingWith(ZarrConstants.FILENAME_DOT_ZARRAY);
     }
 
     @Override
     public TreeSet<String> getGroupKeys() throws IOException {
-        return getKeysFor(ZarrConstants.FILENAME_DOT_ZGROUP);
+        return getKeysEndingWith(ZarrConstants.FILENAME_DOT_ZGROUP);
     }
 
-    private TreeSet<String> getKeysFor(String suffix) throws IOException {
+    @Override
+    public TreeSet<String> getKeysEndingWith(String suffix) throws IOException {
         return Files.walk(internalRoot)
                 .filter(path1 -> path1.toString().endsWith(suffix))
                 .map(path -> internalRoot.relativize(path.getParent()).toString())

--- a/src/test/java/com/bc/zarr/BloscCompressorTest.java
+++ b/src/test/java/com/bc/zarr/BloscCompressorTest.java
@@ -1,0 +1,297 @@
+/*
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020. Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.bc.zarr;
+
+import com.bc.zarr.chunk.ZarrInputStreamAdapter;
+import org.blosc.JBlosc;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.imageio.stream.MemoryCacheImageInputStream;
+import javax.imageio.stream.MemoryCacheImageOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteOrder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class BloscCompressorTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+
+        final String bloscJnaLibraryPath = System.getProperty("bloscJnaLibraryPath");
+        System.err.println(bloscJnaLibraryPath);
+        final boolean bloscPathDefined = bloscJnaLibraryPath != null;
+        final boolean bloscAvailable = isBloscAvailable();
+        if (bloscPathDefined && !bloscAvailable) {
+            Assert.fail("Property for blosc has been configured, but blosc is not available.");
+        } else {
+            Assume.assumeTrue("Blosc library path is not configured. Blosc specifc tests are not executed.", bloscAvailable); // test is skipped if blosc is not available
+        }
+    }
+
+    @Test
+    public void writeRead_BloscCompressor() throws IOException {
+        final Compressor compressor = CompressorFactory.create("blosc");
+        final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
+        final int[] input = {
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100
+        };
+        final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
+        iis.setByteOrder(byteOrder);
+        iis.writeInts(input, 0, input.length);
+        iis.seek(0);
+
+        ByteArrayOutputStream os;
+        ByteArrayInputStream is;
+
+        final byte[] intermediate = {2, 1, 33, 1, -36, 0, 0, 0, -36, 0, 0, 0, 73, 0, 0, 0, 20, 0, 0, 0, 49, 0, 0, 0, -5, 17, 0, 0, 0, 100, 0, 0, 0, 22, 0, 0, 0, 100, 0, 0, 0, 22, 0, 0, 0, 22, 0, 0, 0, 22, 0, 0, 0, 100, 0, 0, 0, 100, 32, 0, 0, 20, 0, 15, 44, 0, -111, 80, 22, 0, 0, 0, 100};
+
+        //write
+        os = new ByteArrayOutputStream();
+        compressor.compress(new ZarrInputStreamAdapter(iis), os);
+        final byte[] compressed = os.toByteArray();
+        assertThat(compressed, is(equalTo(intermediate)));
+
+        //read
+        is = new ByteArrayInputStream(compressed);
+        os = new ByteArrayOutputStream();
+        compressor.uncompress(is, os);
+        final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
+        final MemoryCacheImageInputStream resultIis = new MemoryCacheImageInputStream(bais);
+        resultIis.setByteOrder(byteOrder);
+        final int[] uncompressed = new int[input.length];
+        resultIis.readFully(uncompressed, 0, uncompressed.length);
+        assertThat(input, is(equalTo(uncompressed)));
+    }
+
+    @Test
+    public void read_BloscCompressor_DefaultAvailable() throws IOException {
+        final Compressor compressor = CompressorFactory.create("blosc");
+        final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
+        final int[] input = {
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100
+        };
+        final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
+        iis.setByteOrder(byteOrder);
+        iis.writeInts(input, 0, input.length);
+        iis.seek(0);
+
+        ByteArrayOutputStream os;
+        InputStream is;
+
+        //write
+        os = new ByteArrayOutputStream();
+        compressor.compress(new ZarrInputStreamAdapter(iis), os);
+        final byte[] compressed = os.toByteArray();
+
+        //read
+        is = new MockAWSChecksumValidatingInputStream(new ByteArrayInputStream(compressed), len -> len > 16 ? 7 : len);
+        os = new ByteArrayOutputStream();
+        compressor.uncompress(is, os);
+        final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
+        final MemoryCacheImageInputStream resultIis = new MemoryCacheImageInputStream(bais);
+        resultIis.setByteOrder(byteOrder);
+        final int[] uncompressed = new int[input.length];
+        resultIis.readFully(uncompressed, 0, uncompressed.length);
+        assertThat(uncompressed, is(equalTo(input)));
+    }
+
+    @Test
+    public void read_BloscCompressor_ReducedBytesRead() throws IOException {
+        final Compressor compressor = CompressorFactory.create("blosc");
+        final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
+        final int[] input = {
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
+                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100
+        };
+        final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
+        iis.setByteOrder(byteOrder);
+        iis.writeInts(input, 0, input.length);
+        iis.seek(0);
+
+        ByteArrayOutputStream os;
+        InputStream is;
+
+        //write
+        os = new ByteArrayOutputStream();
+        compressor.compress(new ZarrInputStreamAdapter(iis), os);
+        final byte[] compressed = os.toByteArray();
+
+        //read
+        is = new MockAWSChecksumValidatingInputStream(new ByteArrayInputStream(compressed), len -> len > 1 ? len - 1 : len);
+        os = new ByteArrayOutputStream();
+        compressor.uncompress(is, os);
+        final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
+        final MemoryCacheImageInputStream resultIis = new MemoryCacheImageInputStream(bais);
+        resultIis.setByteOrder(byteOrder);
+        final int[] uncompressed = new int[input.length];
+        resultIis.readFully(uncompressed, 0, uncompressed.length);
+        assertThat(uncompressed, is(equalTo(input)));
+    }
+
+    @Test
+    public void testThatAllSupportedBloscCasesWorksWithAWS() throws IOException {
+        final int[] blocksizes = {0, 200, 2000};
+        for (String cname : CompressorFactory.BloscCompressor.supportedCnames) {
+            for (int cLevel = 0; cLevel < 10; cLevel++) {
+                for (int blocksize : blocksizes) {
+                    for (int shuffle = 0; shuffle < 3; shuffle++) {
+                        final Map<String, Object> bloscProperties = new LinkedHashMap<>();
+                        bloscProperties.put(CompressorFactory.BloscCompressor.keyCname, cname);
+                        bloscProperties.put(CompressorFactory.BloscCompressor.keyClevel, cLevel);
+                        bloscProperties.put(CompressorFactory.BloscCompressor.keyBlocksize, blocksize);
+                        bloscProperties.put(CompressorFactory.BloscCompressor.keyShuffle, shuffle);
+//                        System.out.println("bloscProperties = " + bloscProperties.toString());
+                        final Compressor compressor = CompressorFactory.create("blosc", bloscProperties);
+
+                        final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
+                        final int[] input = new int[4321];
+                        for (int i = 0; i < input.length; i++) {
+                            input[i] = i;
+                        }
+                        final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
+                        iis.setByteOrder(byteOrder);
+                        iis.writeInts(input, 0, input.length);
+                        iis.seek(0);
+
+                        ByteArrayOutputStream os;
+                        InputStream is;
+
+                        //write
+                        os = new ByteArrayOutputStream();
+                        compressor.compress(new ZarrInputStreamAdapter(iis), os);
+                        final byte[] compressed = os.toByteArray();
+
+                        //read
+                        is = new MockAWSChecksumValidatingInputStream(new ByteArrayInputStream(compressed), len -> len > 1 ? len - 1 : len);
+                        os = new ByteArrayOutputStream();
+                        compressor.uncompress(is, os);
+                        final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
+                        final MemoryCacheImageInputStream resultIis = new MemoryCacheImageInputStream(bais);
+                        resultIis.setByteOrder(byteOrder);
+                        final int[] uncompressed = new int[input.length];
+                        resultIis.readFully(uncompressed, 0, uncompressed.length);
+                        assertThat("Testcase: " + bloscProperties, uncompressed, is(equalTo(input)));
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean isBloscAvailable() {
+        try {
+            new JBlosc(); // fails with e.g. UnsatisfiedLinkException if blosc is not available
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    // Simulates a software.amazon.awssdk.services.s3.checksums.ChecksumValidatingInputStream which
+    // does not provide it's own implementation of available() and always returns 0.
+    // Additionally, this class may return less bytes than requested from read(), this is allowed per
+    // the documentation
+    private static class MockAWSChecksumValidatingInputStream extends InputStream {
+
+        private final InputStream in;
+        private final Function<Integer, Integer> getBytesRead;
+
+        public MockAWSChecksumValidatingInputStream(InputStream in, Function<Integer, Integer> getBytesRead) {
+            this.in = in;
+            this.getBytesRead = getBytesRead;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return in.read();
+        }
+
+        /*
+         * From InputStream:
+         *
+         * Reads up to <code>len</code> bytes of data from the input stream into
+         * an array of bytes.  An attempt is made to read as many as
+         * <code>len</code> bytes, but a smaller number may be read.
+         */
+        @Override
+        public int read(byte[] buf, int off, int len) throws IOException {
+            return in.read(buf, off, getBytesRead.apply(len));
+        }
+
+        @Override
+        public synchronized void reset() throws IOException {
+            in.reset();
+        }
+
+        @Override
+        public void close() throws IOException {
+            in.close();
+        }
+    }
+}

--- a/src/test/java/com/bc/zarr/CompressorTest.java
+++ b/src/test/java/com/bc/zarr/CompressorTest.java
@@ -26,28 +26,22 @@
 
 package com.bc.zarr;
 
-import static org.hamcrest.Matchers.*;
-import static org.hamcrest.MatcherAssert.*;
-
 import com.bc.zarr.chunk.ZarrInputStreamAdapter;
-
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.function.Function;
-
-import org.junit.*;
+import org.junit.Test;
 
 import javax.imageio.stream.MemoryCacheImageInputStream;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class CompressorTest {
-
     @Test
     public void writeRead_NullCompressor() throws IOException {
         final Compressor compressor = CompressorFactory.nullCompressor;
@@ -119,225 +113,4 @@ public class CompressorTest {
         assertThat(input, is(equalTo(uncompressed)));
     }
 
-    @Test
-    public void writeRead_BloscCompressor() throws IOException {
-        final Compressor compressor = CompressorFactory.create("blosc");
-        final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
-        final int[] input = {
-                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-                100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100
-        };
-        final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
-        iis.setByteOrder(byteOrder);
-        iis.writeInts(input, 0, input.length);
-        iis.seek(0);
-
-        ByteArrayOutputStream os;
-        ByteArrayInputStream is;
-
-        final byte[] intermediate = {2, 1, 33, 1, -36, 0, 0, 0, -36, 0, 0, 0, 73, 0, 0, 0, 20, 0, 0, 0, 49, 0, 0, 0, -5, 17, 0, 0, 0, 100, 0, 0, 0, 22, 0, 0, 0, 100, 0, 0, 0, 22, 0, 0, 0, 22, 0, 0, 0, 22, 0, 0, 0, 100, 0, 0, 0, 100, 32, 0, 0, 20, 0, 15, 44, 0, -111, 80, 22, 0, 0, 0, 100};
-
-        //write
-        os = new ByteArrayOutputStream();
-        compressor.compress(new ZarrInputStreamAdapter(iis), os);
-        final byte[] compressed = os.toByteArray();
-        assertThat(compressed, is(equalTo(intermediate)));
-
-        //read
-        is = new ByteArrayInputStream(compressed);
-        os = new ByteArrayOutputStream();
-        compressor.uncompress(is, os);
-        final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
-        final MemoryCacheImageInputStream resultIis = new MemoryCacheImageInputStream(bais);
-        resultIis.setByteOrder(byteOrder);
-        final int[] uncompressed = new int[input.length];
-        resultIis.readFully(uncompressed, 0, uncompressed.length);
-        assertThat(input, is(equalTo(uncompressed)));
-    }
-
-    @Test
-    public void read_BloscCompressor_DefaultAvailable() throws IOException {
-        final Compressor compressor = CompressorFactory.create("blosc");
-        final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
-        final int[] input = {
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100
-        };
-        final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
-        iis.setByteOrder(byteOrder);
-        iis.writeInts(input, 0, input.length);
-        iis.seek(0);
-
-        ByteArrayOutputStream os;
-        InputStream is;
-
-        //write
-        os = new ByteArrayOutputStream();
-        compressor.compress(new ZarrInputStreamAdapter(iis), os);
-        final byte[] compressed = os.toByteArray();
-
-        //read
-        is = new MockAWSChecksumValidatingInputStream(new ByteArrayInputStream(compressed), len -> len > 16 ? 7 : len);
-        os = new ByteArrayOutputStream();
-        compressor.uncompress(is, os);
-        final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
-        final MemoryCacheImageInputStream resultIis = new MemoryCacheImageInputStream(bais);
-        resultIis.setByteOrder(byteOrder);
-        final int[] uncompressed = new int[input.length];
-        resultIis.readFully(uncompressed, 0, uncompressed.length);
-        assertThat(uncompressed, is(equalTo(input)));
-    }
-
-    @Test
-    public void read_BloscCompressor_ReducedBytesRead() throws IOException {
-        final Compressor compressor = CompressorFactory.create("blosc");
-        final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
-        final int[] input = {
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100,
-            100, 22, 100, 22, 22, 22, 100, 100, 100, 22, 100
-        };
-        final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
-        iis.setByteOrder(byteOrder);
-        iis.writeInts(input, 0, input.length);
-        iis.seek(0);
-
-        ByteArrayOutputStream os;
-        InputStream is;
-
-        //write
-        os = new ByteArrayOutputStream();
-        compressor.compress(new ZarrInputStreamAdapter(iis), os);
-        final byte[] compressed = os.toByteArray();
-
-        //read
-        is = new MockAWSChecksumValidatingInputStream(new ByteArrayInputStream(compressed), len -> len > 1 ? len - 1 : len);
-        os = new ByteArrayOutputStream();
-        compressor.uncompress(is, os);
-        final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
-        final MemoryCacheImageInputStream resultIis = new MemoryCacheImageInputStream(bais);
-        resultIis.setByteOrder(byteOrder);
-        final int[] uncompressed = new int[input.length];
-        resultIis.readFully(uncompressed, 0, uncompressed.length);
-        assertThat(uncompressed, is(equalTo(input)));
-    }
-
-    @Test
-    public void testThatAllSupportedBloscCasesWorksWithAWS() throws IOException {
-        final int[] blocksizes = {0, 200, 2000};
-        for (String cname : CompressorFactory.BloscCompressor.supportedCnames) {
-            for (int cLevel = 0; cLevel < 10; cLevel++) {
-                for (int blocksize : blocksizes) {
-                    for (int shuffle = 0; shuffle < 3 ; shuffle++) {
-                        final Map<String, Object> bloscProperties = new LinkedHashMap<>();
-                        bloscProperties.put(CompressorFactory.BloscCompressor.keyCname, cname);
-                        bloscProperties.put(CompressorFactory.BloscCompressor.keyClevel, cLevel);
-                        bloscProperties.put(CompressorFactory.BloscCompressor.keyBlocksize, blocksize);
-                        bloscProperties.put(CompressorFactory.BloscCompressor.keyShuffle, shuffle);
-//                        System.out.println("bloscProperties = " + bloscProperties.toString());
-                        final Compressor compressor = CompressorFactory.create("blosc", bloscProperties);
-
-                        final ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
-                        final int[] input = new int[4321];
-                        for (int i = 0; i < input.length; i++) {
-                            input[i] = i;
-                        }
-                        final MemoryCacheImageOutputStream iis = new MemoryCacheImageOutputStream(new ByteArrayOutputStream());
-                        iis.setByteOrder(byteOrder);
-                        iis.writeInts(input, 0, input.length);
-                        iis.seek(0);
-
-                        ByteArrayOutputStream os;
-                        InputStream is;
-
-                        //write
-                        os = new ByteArrayOutputStream();
-                        compressor.compress(new ZarrInputStreamAdapter(iis), os);
-                        final byte[] compressed = os.toByteArray();
-
-                        //read
-                        is = new MockAWSChecksumValidatingInputStream(new ByteArrayInputStream(compressed), len -> len > 1 ? len - 1 : len);
-                        os = new ByteArrayOutputStream();
-                        compressor.uncompress(is, os);
-                        final ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
-                        final MemoryCacheImageInputStream resultIis = new MemoryCacheImageInputStream(bais);
-                        resultIis.setByteOrder(byteOrder);
-                        final int[] uncompressed = new int[input.length];
-                        resultIis.readFully(uncompressed, 0, uncompressed.length);
-                        assertThat("Testcase: " + bloscProperties.toString(), uncompressed, is(equalTo(input)));
-                    }
-                }
-            }
-        }
-    }
-
-    // Simulates a software.amazon.awssdk.services.s3.checksums.ChecksumValidatingInputStream which
-    // does not provide it's own implementation of available() and always returns 0.
-    // Additionally, this class may return less bytes than requested from read(), this is allowed per
-    // the documentation
-    private static class MockAWSChecksumValidatingInputStream extends InputStream {
-
-        private final InputStream in;
-        private final Function<Integer, Integer> getBytesRead;
-
-        public MockAWSChecksumValidatingInputStream(InputStream in, Function<Integer, Integer> getBytesRead) {
-            this.in = in;
-            this.getBytesRead = getBytesRead;
-        }
-
-        @Override
-        public int read() throws IOException {
-            return in.read();
-        }
-
-        /*
-         * From InputStream:
-         *
-         * Reads up to <code>len</code> bytes of data from the input stream into
-         * an array of bytes.  An attempt is made to read as many as
-         * <code>len</code> bytes, but a smaller number may be read.
-         */
-        @Override
-        public int read(byte[] buf, int off, int len) throws IOException {
-            return in.read(buf, off, getBytesRead.apply(len));
-        }
-
-        @Override
-        public synchronized void reset() throws IOException {
-            in.reset();
-        }
-
-        @Override
-        public void close() throws IOException {
-            in.close();
-        }
-    }
 }

--- a/template.blosc.properties
+++ b/template.blosc.properties
@@ -1,4 +1,4 @@
-# Make a copy of this file in the same directory and rename it from "template.maven.properties" to "maven.properties".
+# Make a copy of this file in the same directory and rename it from "template.blosc.properties" to "blosc.properties".
 # Replace "<...>" marked values of properties with real values.
 
 # On Windows the library is not part of the system. It has to be compiled.


### PR DESCRIPTION
Introduced USE_BLOSC profile in maven, this allwos skipping blosc tests if blosc library is not available and not configured

- renamed maven.properties to blosc.properties, and the template too
- moved blosc tests into seperate class
- updated Readme.md
- updated .gitignore as necessary