### PR TITLE
Support the use of multiple threads to download chunks

### DIFF
--- a/src/test/java/com/bc/zarr/ZarrArrayDataReaderWriterTest_2D_writeAndReadData.java
+++ b/src/test/java/com/bc/zarr/ZarrArrayDataReaderWriterTest_2D_writeAndReadData.java
@@ -29,8 +29,15 @@ package com.bc.zarr;
 import com.bc.zarr.storage.FileSystemStore;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 import ucar.ma2.InvalidRangeException;
 
 import java.io.IOException;
@@ -40,10 +47,25 @@ import java.nio.file.Path;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+@RunWith(Parameterized.class)
 public class ZarrArrayDataReaderWriterTest_2D_writeAndReadData {
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {null},
+            {ForkJoinPool.commonPool()},
+        });
+    }
 
     private String arrayName;
     private FileSystemStore store;
+    private final Executor executor;
+
+    public ZarrArrayDataReaderWriterTest_2D_writeAndReadData(Executor executor) {
+        this.executor = executor;
+    }
+
 
     @Before
     public void setUp() throws Exception {
@@ -102,7 +124,11 @@ public class ZarrArrayDataReaderWriterTest_2D_writeAndReadData {
         final byte[] targetBuffer = new byte[sourceBuffer.length];
 
         //execution
-        array.read(targetBuffer, shape, new int[]{0, 0});
+        if(executor == null) {
+            array.read(targetBuffer, shape, new int[]{0, 0});
+        } else {
+            array.readConcurrently(targetBuffer, shape, new int[]{0, 0}, executor);
+        }
 
         //verification
         assertThat(targetBuffer, is(equalTo(sourceBuffer)));
@@ -138,7 +164,11 @@ public class ZarrArrayDataReaderWriterTest_2D_writeAndReadData {
         final short[] targetBuffer = new short[sourceBuffer.length];
 
         //execution
-        array.read(targetBuffer, shape, new int[]{0, 0});
+        if(executor == null) {
+            array.read(targetBuffer, shape, new int[]{0, 0});
+        } else {
+            array.readConcurrently(targetBuffer, shape, new int[]{0, 0}, executor);
+        }
 
         //verification
         assertThat(targetBuffer, is(equalTo(sourceBuffer)));
@@ -173,7 +203,11 @@ public class ZarrArrayDataReaderWriterTest_2D_writeAndReadData {
         final int[] targetBuffer = new int[sourceBuffer.length];
 
         //execution
-        array.read(targetBuffer, shape, new int[]{0, 0});
+        if(executor == null) {
+            array.read(targetBuffer, shape, new int[]{0, 0});
+        } else {
+            array.readConcurrently(targetBuffer, shape, new int[]{0, 0}, executor);
+        }
 
         //verification
         assertThat(targetBuffer, is(equalTo(sourceBuffer)));
@@ -208,7 +242,11 @@ public class ZarrArrayDataReaderWriterTest_2D_writeAndReadData {
         final float[] targetBuffer = new float[sourceBuffer.length];
 
         //execution
-        array.read(targetBuffer, shape, new int[]{0, 0});
+        if(executor == null) {
+            array.read(targetBuffer, shape, new int[]{0, 0});
+        } else {
+            array.readConcurrently(targetBuffer, shape, new int[]{0, 0}, executor);
+        }
 
         //verification
         assertThat(targetBuffer, is(equalTo(sourceBuffer)));
@@ -244,7 +282,11 @@ public class ZarrArrayDataReaderWriterTest_2D_writeAndReadData {
         final double[] targetBuffer = new double[sourceBuffer.length];
 
         //execution
-        array.read(targetBuffer, shape, new int[]{0, 0});
+        if(executor == null) {
+            array.read(targetBuffer, shape, new int[]{0, 0});
+        } else {
+            array.readConcurrently(targetBuffer, shape, new int[]{0, 0}, executor);
+        }
 
         //verification
         assertThat(targetBuffer, is(equalTo(sourceBuffer)));


### PR DESCRIPTION
I am comparing the performance of the JZarr and Python zarr, in particular with the use of AWS S3.  There is a huge performance gap between the two with S3.  In my test setup, it took about 20 minutes to read a Zarr store with JZarr and Java S3FS, compared to 20 seconds with Python Zarr and the Python S3FS.

I discovered that Java S3FS is horribly inefficient, making repeated network calls to check for the existence of files and check permissions.  With S3FS, a download which requires only a single network call was using 4 or 5.  I implemented my own S3 com.bc.zarr.storage.Store using the pure Java AWS SDK and that helped significantly.  This was still not as good as Python though (3-4x worse).

I looked at the network calls the Python library was using, and it looks like it is making multiple simultaneous requests when getting chunks.  

Here is a snippet:
```
2021-11-15 22:21:18,965 - s3fs - DEBUG - _call_s3 -- CALL: get_object - () - {'Bucket': 'echofish-dev-master-118234403147-echofish-zarr-store', 'Key': 'AL0502_resample.zarr/latitude/1275'}
2021-11-15 22:21:18,967 - s3fs - DEBUG - _call_s3 -- CALL: get_object - () - {'Bucket': 'echofish-dev-master-118234403147-echofish-zarr-store', 'Key': 'AL0502_resample.zarr/latitude/1276'}
2021-11-15 22:21:18,969 - s3fs - DEBUG - _call_s3 -- CALL: get_object - () - {'Bucket': 'echofish-dev-master-118234403147-echofish-zarr-store', 'Key': 'AL0502_resample.zarr/latitude/1277'}
2021-11-15 22:21:18,970 - s3fs - DEBUG - _call_s3 -- CALL: get_object - () - {'Bucket': 'echofish-dev-master-118234403147-echofish-zarr-store', 'Key': 'AL0502_resample.zarr/latitude/1278'}
2021-11-15 22:21:18,972 - s3fs - DEBUG - _call_s3 -- CALL: get_object - () - {'Bucket': 'echofish-dev-master-118234403147-echofish-zarr-store', 'Key': 'AL0502_resample.zarr/latitude/1279'}
2021-11-15 22:21:18,974 - s3fs - DEBUG - _call_s3 -- CALL: get_object - () - {'Bucket': 'echofish-dev-master-118234403147-echofish-zarr-store', 'Key': 'AL0502_resample.zarr/latitude/1280'}
2021-11-15 22:21:18,975 - s3fs - DEBUG - _call_s3 -- CALL: get_object - () - {'Bucket': 'echofish-dev-master-118234403147-echofish-zarr-store', 'Key': 'AL0502_resample.zarr/latitude/1281'}
2021-11-15 22:21:18,977 - s3fs - DEBUG - _call_s3 -- CALL: get_object - () - {'Bucket': 'echofish-dev-master-118234403147-echofish-zarr-store', 'Key': 'AL0502_resample.zarr/latitude/1282'}
```
Note the timestamps are within a couple milliseconds.

I updated JZarr to support multiple download threads for the chunks and was able to match (and slightly beat) the Python performance.

Here are the outputs from two programs, one in Python and one in Java with these changes:

Python:
```
Time 1249
43520
Time 1190
87040
Time 1180
130560
Time 1253
174080
Time 1120
217600
Time 1242
261120
Time 1224
304640
Time 2488
348160
Time 2776
391680
Time 1177
435200
Time 1265
478720
Time 1349
522240
Time 1218
565760
Time 1220
609280
Time 1236
652800
Time 1268
696320
Total Time 23414
```

Java
```
Start
Time 1397
43520
Time 1202
87040
Time 1256
130560
Time 1323
174080
Time 1289
217600
Time 1129
261120
Time 1186
304640
Time 1153
348160
Time 1252
391680
Time 1100
435200
Time 1111
478720
Time 1133
522240
Time 1199
565760
Time 1114
609280
Time 1141
652800
Time 1157
696320
Total Time 20511
```

What are your thoughts on these changes? 

For reference, the two test programs:
```python
import s3fs
import zarr
import time

def current_milli_time():
  return round(time.time() * 1000)

start = current_milli_time()

s3 = s3fs.S3FileSystem(anon=False, profile="echofish")
store = s3fs.S3Map(root='echofish-dev-master-118234403147-echofish-zarr-store/AL0502_resample.zarr', s3=s3, check=False)
root = zarr.group(store=store)

latitude = root['latitude']
longitude = root['longitude']
timeArray = root['time']

count = latitude.shape[0]
readCount = 0
bufferSize = 43520
while (readCount < count):
  readSize = min(bufferSize, count - readCount)
  i_start = current_milli_time()
  lat_data = latitude[readCount:(readSize + readCount)]
  lon_data = longitude[readCount:(readSize + readCount)]
  time_data = timeArray[readCount:(readSize + readCount)]
  i_end = current_milli_time()
  print('Time ' + str(i_end - i_start))
  readCount = readCount + readSize
  print(readCount)

end = current_milli_time()
print('Total Time ' + str(end - start))
```

```java
  private void read(ZarrArray zarrArray, int readSize, int offset) {
    try {
      zarrArray.readConcurrently(new int[]{readSize}, new int[]{offset}, ForkJoinPool.commonPool());
    } catch (Exception e) {
      throw new RuntimeException(e);
    }
  }

  @Test
  public void testReadAll() throws Exception {

    System.setProperty("aws.profile", "echofish");

    System.setProperty("aws.region", "us-west-2");

    long st = System.currentTimeMillis();

    try (S3Client s3 = S3Client.builder().build()) {
      ZarrGroup zarrGroup = ZarrGroup.open(new AwsS3ZarrStore(s3BucketName, "AL0502_resample.zarr", s3));
      
      ZarrArray latitudeArray = zarrGroup.openArray("latitude");
      ZarrArray longitudeArray = zarrGroup.openArray("longitude");
      ZarrArray timeArray = zarrGroup.openArray("time");
      int count = latitudeArray.getShape()[0];
      int readCount = 0;
      System.out.println("Start");
      int bufferSize = DataPointZarrIterator.DEFAULT_BUFFER_SIZE;
      while (readCount < count) {
        int readSize = Math.min(bufferSize, count - readCount);
        int rc = readCount;
        long start = System.currentTimeMillis();
        read(latitudeArray, readSize, rc);
        read(longitudeArray, readSize, rc);
        read(timeArray, readSize, rc);
        long end = System.currentTimeMillis();
        System.out.println("Time " + (end - start));
        readCount = readCount + readSize;
        System.out.println(readCount);
      }
    }

    long e = System.currentTimeMillis();
    System.out.println("Total Time " + (e - st));

  }
```
```java
package edu.colorado.cires.cmg.echofish.aws.lambda.mvt;

import com.bc.zarr.ZarrConstants;
import com.bc.zarr.ZarrUtils;
import com.bc.zarr.storage.Store;
import java.io.IOException;
import java.io.InputStream;
import java.io.OutputStream;
import java.util.Arrays;
import java.util.List;
import java.util.TreeSet;
import java.util.stream.Collectors;
import java.util.stream.Stream;
import software.amazon.awssdk.services.s3.S3Client;
import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
import software.amazon.awssdk.services.s3.model.S3Object;

public class AwsS3ZarrStore implements Store {

  private final String bucket;
  private final String prefix;
  private final int prefixLength;
  private final S3Client s3;

  public AwsS3ZarrStore(String bucket, String prefix, S3Client s3) {
    this.bucket = bucket;
    this.prefix = ZarrUtils.normalizeStoragePath(prefix);
    this.s3 = s3;
    this.prefixLength = split(this.prefix).size();
  }

  @Override
  public InputStream getInputStream(String key) throws IOException {
    return s3.getObject(builder -> builder.bucket(bucket).key(prefix.isEmpty() ? "" : prefix + "/" + ZarrUtils.normalizeStoragePath(key)));
  }

  @Override
  public OutputStream getOutputStream(String key) throws IOException {
    throw new UnsupportedOperationException("getOutputStream is not implemented");
  }

  @Override
  public void delete(String key) throws IOException {
    throw new UnsupportedOperationException("delete is not implemented");
  }

  private static List<String> split(String key) {
    return Arrays.asList(key.split("/"));
  }

  private TreeSet<String> getParentsOf(String suffix) throws IOException {
    return getKeysEndingWith(suffix).stream()
        .map(AwsS3ZarrStore::split)
        .map(split -> split.subList(0, split.size() - 1))
        .map(split -> String.join("/", split))
        .collect(Collectors.toCollection(TreeSet::new));
  }

  @Override
  public TreeSet<String> getArrayKeys() throws IOException {
    return getParentsOf(ZarrConstants.FILENAME_DOT_ZARRAY);
  }

  @Override
  public TreeSet<String> getGroupKeys() throws IOException {
    return getParentsOf(ZarrConstants.FILENAME_DOT_ZGROUP);
  }

  @Override
  public TreeSet<String> getKeysEndingWith(String suffix) throws IOException {
    try (Stream<ListObjectsV2Response> stream = s3.listObjectsV2Paginator(builder -> builder.bucket(bucket).prefix(prefix)).stream()) {
      return
          stream.flatMap(response -> response.contents().stream())
              .map(S3Object::key)
              .map(ZarrUtils::normalizeStoragePath)
              .map(AwsS3ZarrStore::split)
              .map(split -> String.join("/", split.subList(prefixLength, split.size())))
              .filter(s -> s.trim().length() > 0)
              .collect(Collectors.toCollection(TreeSet::new));
    }

  }

  @Override
  public Stream<String> getRelativeLeafKeys(String key) throws IOException {
    String normalizedKey = ZarrUtils.normalizeStoragePath(key);
    String relativePrefix = (prefix.isEmpty() ? "" : prefix) + (normalizedKey.isEmpty() ? "" : "/" + normalizedKey);
    int length = split(relativePrefix).size();
    try (Stream<ListObjectsV2Response> stream = s3.listObjectsV2Paginator(builder -> builder.bucket(bucket).prefix(relativePrefix))
        .stream()) {
      return
          stream.flatMap(response -> response.contents().stream())
              .map(S3Object::key)
              .map(ZarrUtils::normalizeStoragePath)
              .map(AwsS3ZarrStore::split)
              .map(split -> String.join("/", split.subList(length, split.size())))
              .filter(s -> s.trim().length() > 0)
              .collect(Collectors.toCollection(TreeSet::new))
              .stream();  // wrap in collection and then stream as caller does not close the stream
    }

  }
}
```